### PR TITLE
Prevent hang on close after capturing audio

### DIFF
--- a/alsaaudio.c
+++ b/alsaaudio.c
@@ -440,6 +440,7 @@ alsapcm_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 static void alsapcm_dealloc(alsapcm_t *self)
 {
     if (self->handle) {
+        snd_pcm_pause(self->handle, 1);
         snd_pcm_drain(self->handle);
         snd_pcm_close(self->handle);
     }


### PR DESCRIPTION
Currently, after recording audio using pyalsaaudio, the client is unable to close the device.

The reason is that PulseAudio client tries to drain the pipe to the PulseAudio server (presumably in order to prevent Broken Pipe error) on closing. That will never finish since new data will always arrive in the pipe.

Worse, the __del__ handler was auto-closing and thus auto-hanging.

Therefore, pause before de-allocating.