### PR TITLE
Fix #51: Only return valid part of the buffer in the read function

### DIFF
--- a/alsaaudio.c
+++ b/alsaaudio.c
@@ -1051,7 +1051,7 @@ alsapcm_read(alsapcm_t *self, PyObject *args)
 {
 	int res;
 	int size = self->framesize * self->periodsize;
-	int sizeout;
+	int sizeout = 0;
 	PyObject *buffer_obj, *tuple_obj, *res_obj;
 	char *buffer;
 
@@ -1106,12 +1106,11 @@ alsapcm_read(alsapcm_t *self, PyObject *args)
 		}
 	}
 
-	if (res <= 0) {
-		sizeout = 0;
-	} else {
+	if (res > 0 ) {
 		sizeout = res * self->framesize;
 	}
 	
+	if (size != sizeout) {
 #if PY_MAJOR_VERSION < 3
 		/* If the following fails, it will free the object */
 		if (_PyString_Resize(&buffer_obj, sizeout))
@@ -1121,7 +1120,8 @@ alsapcm_read(alsapcm_t *self, PyObject *args)
 		if (_PyBytes_Resize(&buffer_obj, sizeout))
 			return NULL;
 #endif
-
+	}
+	
 	res_obj = PyLong_FromLong(res);
 	if (!res_obj) {
 		Py_DECREF(buffer_obj);

--- a/alsaaudio.c
+++ b/alsaaudio.c
@@ -1051,6 +1051,7 @@ alsapcm_read(alsapcm_t *self, PyObject *args)
 {
 	int res;
 	int size = self->framesize * self->periodsize;
+	int sizeout;
 	PyObject *buffer_obj, *tuple_obj, *res_obj;
 	char *buffer;
 
@@ -1106,16 +1107,20 @@ alsapcm_read(alsapcm_t *self, PyObject *args)
 	}
 
 	if (res <= 0) {
+		sizeout = 0;
+	} else {
+		sizeout = res * self->framesize;
+	}
+	
 #if PY_MAJOR_VERSION < 3
 		/* If the following fails, it will free the object */
-		if (_PyString_Resize(&buffer_obj, 0))
+		if (_PyString_Resize(&buffer_obj, sizeout))
 			return NULL;
 #else
 		/* If the following fails, it will free the object */
-		if (_PyBytes_Resize(&buffer_obj, 0))
+		if (_PyBytes_Resize(&buffer_obj, sizeout))
 			return NULL;
 #endif
-	}
 
 	res_obj = PyLong_FromLong(res);
 	if (!res_obj) {


### PR DESCRIPTION
Not returning the invalid part of the buffer solves problems with the initial size of the buffer anticipating more data than actually provided.

I am 99% sure the size calculation is correct, but not entirely as I am not that acquainted with ALSA and this lowlevel python module programming. I replayed the raw recording made with a modified recordtest.py using audacity and it is fine now.