### PR TITLE
Add timestamp_raw function

### DIFF
--- a/alsaaudio.c
+++ b/alsaaudio.c
@@ -639,6 +639,39 @@ alsapcm_dumpinfo(alsapcm_t *self, PyObject *args)
 	return Py_None;
 }
 
+static PyObject *
+alsapcm_timestamp_raw(alsapcm_t *self, PyObject *args)
+{
+	snd_htimestamp_t tstamp;
+	snd_pcm_uframes_t avail;
+	PyObject *result = NULL;
+	// int err;
+
+	/* snd_pcm_status_t *status;
+	snd_pcm_status_alloca(&status);
+
+	if ((err = snd_pcm_status(self->handle, status)) < 0) {
+		printf("Stream status error: %s\n", snd_strerror(err));
+		exit(0);
+	}*/
+
+	snd_pcm_htimestamp(self->handle , &avail, &tstamp);
+
+	result = PyTuple_New(3);
+	PyTuple_SetItem(result, 0, PyLong_FromLongLong(tstamp.tv_sec));
+	PyTuple_SetItem(result, 1, PyLong_FromLong(tstamp.tv_nsec));
+	PyTuple_SetItem(result, 2, PyLong_FromLong(avail));
+
+	return result;
+}
+
+PyDoc_STRVAR(pcm_timestampraw_doc,
+"timestamp() -> tuple\n\
+\n\
+Returns a tuple containing the seconds since epoch in the first element \n\
+, nanoseconds in the second element, and available number of frames at the time of the time stamp.'. \n\
+");
+
 // auxiliary function
 
 
@@ -1375,6 +1408,8 @@ static PyMethodDef alsapcm_methods[] = {
 	{"setformat", (PyCFunction)alsapcm_setformat, METH_VARARGS, setformat_doc},
 	{"setperiodsize", (PyCFunction)alsapcm_setperiodsize, METH_VARARGS,
 	 setperiodsize_doc},
+	{"timestamp_raw", (PyCFunction) alsapcm_timestamp_raw, METH_VARARGS,
+	 pcm_timestampraw_doc},
 	{"dumpinfo", (PyCFunction)alsapcm_dumpinfo, METH_VARARGS},
 	{"getformats", (PyCFunction)alsapcm_getformats, METH_VARARGS, getformats_doc},
 	{"getratebounds", (PyCFunction)alsapcm_getratemaxmin, METH_VARARGS, getratebounds_doc},

--- a/alsaaudio.c
+++ b/alsaaudio.c
@@ -639,21 +639,13 @@ alsapcm_dumpinfo(alsapcm_t *self, PyObject *args)
 	return Py_None;
 }
 
+
 static PyObject *
 alsapcm_timestamp_raw(alsapcm_t *self, PyObject *args)
 {
 	snd_htimestamp_t tstamp;
 	snd_pcm_uframes_t avail;
 	PyObject *result = NULL;
-	// int err;
-
-	/* snd_pcm_status_t *status;
-	snd_pcm_status_alloca(&status);
-
-	if ((err = snd_pcm_status(self->handle, status)) < 0) {
-		printf("Stream status error: %s\n", snd_strerror(err));
-		exit(0);
-	}*/
 
 	snd_pcm_htimestamp(self->handle , &avail, &tstamp);
 
@@ -664,6 +656,7 @@ alsapcm_timestamp_raw(alsapcm_t *self, PyObject *args)
 
 	return result;
 }
+
 
 PyDoc_STRVAR(pcm_timestampraw_doc,
 "timestamp() -> tuple\n\

--- a/alsaaudio.c
+++ b/alsaaudio.c
@@ -641,7 +641,7 @@ alsapcm_dumpinfo(alsapcm_t *self, PyObject *args)
 
 
 static PyObject *
-alsapcm_timestamp_raw(alsapcm_t *self, PyObject *args)
+alsapcm_htimestamp(alsapcm_t *self, PyObject *args)
 {
 	snd_htimestamp_t tstamp;
 	snd_pcm_uframes_t avail;
@@ -658,12 +658,12 @@ alsapcm_timestamp_raw(alsapcm_t *self, PyObject *args)
 }
 
 
-PyDoc_STRVAR(pcm_timestampraw_doc,
-"timestamp() -> tuple\n\
+PyDoc_STRVAR(pcm_htimestamp_doc,
+"htimestamp() -> tuple\n\
 \n\
 Returns a tuple containing the seconds since epoch in the first element \n\
-, nanoseconds in the second element, and available number of frames at the time of the time stamp.'. \n\
-");
+, nanoseconds in the second element, and number of frames available in \n\
+ the buffer at the time of the time stamp. \n");
 
 // auxiliary function
 
@@ -1401,8 +1401,8 @@ static PyMethodDef alsapcm_methods[] = {
 	{"setformat", (PyCFunction)alsapcm_setformat, METH_VARARGS, setformat_doc},
 	{"setperiodsize", (PyCFunction)alsapcm_setperiodsize, METH_VARARGS,
 	 setperiodsize_doc},
-	{"timestamp_raw", (PyCFunction) alsapcm_timestamp_raw, METH_VARARGS,
-	 pcm_timestampraw_doc},
+	{"htimestamp", (PyCFunction) alsapcm_htimestamp, METH_VARARGS,
+	 pcm_htimestamp_doc},
 	{"dumpinfo", (PyCFunction)alsapcm_dumpinfo, METH_VARARGS},
 	{"getformats", (PyCFunction)alsapcm_getformats, METH_VARARGS, getformats_doc},
 	{"getratebounds", (PyCFunction)alsapcm_getratemaxmin, METH_VARARGS, getratebounds_doc},


### PR DESCRIPTION
For many IoT applications timestamps generated at the acquiring device are required. Currently pyalsaaudio does not support obtaining timestamps from the audio card itself.

However, ALSA contains a function snd_pcm_htimestamp which yields a high resolution timestamp. (Documentation here: https://www.alsa-project.org/alsa-doc/alsa-lib/group___p_c_m.html#ga3946abd34178b3de60fd5329b71c189b)

This timestamp still needs interpretation therefore I propose to call the pyalsaaudio equivalent "timestamp_raw", so "timestamp" with an added "raw" to stress that the output needs to be interpreted.

The 3 values returned in a tuple are seconds, nanoseconds and the available samples in the buffer at the moment the timestamp was grabbed. If I read the documentation correctly.




