### PR TITLE
Feature timestamp mode and type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ gh-pages/
 build/
 dist/
 .vscode/
+/__pycache__/
+/pyalsaaudio.egg-info/
+*.raw

--- a/alsaaudio.c
+++ b/alsaaudio.c
@@ -830,14 +830,10 @@ they represent values stored by pyalsaaudio and they are prefixed with ' (call v
 static PyObject *
 alsa_asoundlib_version(PyObject * module, PyObject *args)
 {
-	PyObject *value;
-
 	if (!PyArg_ParseTuple(args,":asoundlib_version"))
 		return NULL;
 
-	value=PyUnicode_FromString(snd_asoundlib_version());
-
-	return value;
+	return PyUnicode_FromString(snd_asoundlib_version());
 }
 
 PyDoc_STRVAR(asoundlib_version_doc,
@@ -901,6 +897,7 @@ alsapcm_set_tstamp_mode(alsapcm_t *self, PyObject *args)
 		return NULL;
 	}
 
+	Py_INCREF(Py_None);
 	return Py_None;
 }
 
@@ -916,9 +913,6 @@ alsapcm_get_tstamp_mode(alsapcm_t *self, PyObject *args)
 {
 	snd_pcm_tstamp_t mode;
 	int err;
-
-
-	PyObject *value;
 
 	if (!PyArg_ParseTuple(args,":get_tstamp_mode"))
 		return NULL;
@@ -941,8 +935,7 @@ alsapcm_get_tstamp_mode(alsapcm_t *self, PyObject *args)
 		return NULL;
 	}
 
-	value = PyLong_FromUnsignedLong((unsigned long) mode);
-	return value;
+	return PyLong_FromUnsignedLong((unsigned long) mode);
 }
 
 
@@ -981,6 +974,7 @@ alsapcm_set_tstamp_type(alsapcm_t *self, PyObject *args)
 		return NULL;
 	}
 
+	Py_INCREF(Py_None);
 	return Py_None;
 }
 
@@ -995,9 +989,6 @@ alsapcm_get_tstamp_type(alsapcm_t *self, PyObject *args)
 {
 	snd_pcm_tstamp_type_t type;
 	int err;
-
-
-	PyObject *value;
 
 	if (!PyArg_ParseTuple(args,":get_tstamp_type"))
 		return NULL;
@@ -1020,8 +1011,7 @@ alsapcm_get_tstamp_type(alsapcm_t *self, PyObject *args)
 		return NULL;
 	}
 
-	value = PyLong_FromUnsignedLong((unsigned long) type);
-	return value;
+	return PyLong_FromUnsignedLong((unsigned long) type);
 }
 
 

--- a/alsaaudio.c
+++ b/alsaaudio.c
@@ -856,6 +856,7 @@ Returns a tuple containing the seconds since epoch in the first element \n\
 static PyObject *
 alsapcm_enable_timestamp(alsapcm_t *self, PyObject *args)
 {
+    int err;
 
 	snd_pcm_sw_params_t* swParams;
 	snd_pcm_sw_params_alloca( &swParams);
@@ -864,7 +865,12 @@ alsapcm_enable_timestamp(alsapcm_t *self, PyObject *args)
 
 	snd_pcm_sw_params_set_tstamp_mode(self->handle, swParams, SND_PCM_TSTAMP_ENABLE);
 	snd_pcm_sw_params_set_tstamp_type(self->handle, swParams, SND_PCM_TSTAMP_TYPE_GETTIMEOFDAY);
-	snd_pcm_sw_params(self->handle, swParams);
+	err = snd_pcm_sw_params(self->handle, swParams);
+
+	if (err < 0) {
+		PyErr_SetString(PyExc_RuntimeError, "Unable to set sw params for input capture!");
+		return NULL;
+	}
 
 	return Py_None;
 }

--- a/alsaaudio.c
+++ b/alsaaudio.c
@@ -852,6 +852,29 @@ Returns a tuple containing the seconds since epoch in the first element \n\
 , nanoseconds in the second element, and number of frames available in \n\
  the buffer at the time of the time stamp. \n");
 
+
+static PyObject *
+alsapcm_enable_timestamp(alsapcm_t *self, PyObject *args)
+{
+
+	snd_pcm_sw_params_t* swParams;
+	snd_pcm_sw_params_alloca( &swParams);
+
+	snd_pcm_sw_params_current(self->handle, swParams);
+
+	snd_pcm_sw_params_set_tstamp_mode(self->handle, swParams, SND_PCM_TSTAMP_ENABLE);
+	snd_pcm_sw_params_set_tstamp_type(self->handle, swParams, SND_PCM_TSTAMP_TYPE_GETTIMEOFDAY);
+	snd_pcm_sw_params(self->handle, swParams);
+
+	return Py_None;
+}
+
+
+PyDoc_STRVAR(alsapcm_enable_timestamp_doc,
+"enable_timestamp() -> tuple\n\
+\n\
+Hic sunt dragonis \n");
+
 // auxiliary function
 
 
@@ -1590,6 +1613,7 @@ static PyMethodDef alsapcm_methods[] = {
 	 setperiodsize_doc},
 	{"htimestamp", (PyCFunction) alsapcm_htimestamp, METH_VARARGS,
 	 pcm_htimestamp_doc},
+	{"enable_timestamp", (PyCFunction) alsapcm_enable_timestamp, METH_VARARGS, alsapcm_enable_timestamp_doc},
 	{"dumpinfo", (PyCFunction)alsapcm_dumpinfo, METH_VARARGS},
 	{"info", (PyCFunction)alsapcm_info, METH_VARARGS, pcm_info_doc},
 	{"getformats", (PyCFunction)alsapcm_getformats, METH_VARARGS, getformats_doc},

--- a/doc/libalsaaudio.rst
+++ b/doc/libalsaaudio.rst
@@ -97,6 +97,9 @@ The :mod:`alsaaudio` module defines functions and classes for using ALSA.
      changed. Since 0.8, this functions returns the mixers for the default
      device, not the mixers for the first card.
 
+.. function:: asoundlib_version()
+
+   Return a Python string containing the ALSA version found.
 
 .. _pcm-objects:
 
@@ -259,6 +262,56 @@ PCM objects have the following methods:
 
    The *eventmask* value is compatible with `poll.register`__ in the Python 
    :const:`select` module.
+
+.. method:: PCM.set_tstamp_mode([mode=PCM_TSTAMP_ENABLE])
+
+   Set the ALSA timestamp mode on the device. The mode argument can be set to
+   either :const:`PCM_TSTAMP_NONE` or :const:`PCM_TSTAMP_ENABLE`.
+
+.. method:: PCM.get_tstamp_mode()
+
+   Return the integer value corresponding to the ALSA timestamp mode. The
+   return value can be either :const:`PCM_TSTAMP_NONE` or :const:`PCM_TSTAMP_ENABLE`.
+
+.. method:: PCM.set_tstamp_type([type=PCM_TSTAMP_TYPE_GETTIMEOFDAY])
+
+   Set the ALSA timestamp mode on the device. The type argument
+   can be set to either :const:`PCM_TSTAMP_TYPE_GETTIMEOFDAY`,
+   :const:`PCM_TSTAMP_TYPE_MONOTONIC` or :const:`PCM_TSTAMP_TYPE_MONOTONIC_RAW`.
+
+.. method:: PCM.get_tstamp_type()
+
+   Return the integer value corresponding to the ALSA timestamp type. The
+   return value can be either :const:`PCM_TSTAMP_TYPE_GETTIMEOFDAY`,
+   :const:`PCM_TSTAMP_TYPE_MONOTONIC` or :const:`PCM_TSTAMP_TYPE_MONOTONIC_RAW`.
+
+.. method:: PCM.htimestamp()
+
+   Return a Python tuple *(seconds, nanoseconds, frames_available_in_buffer)*.
+
+   The type of output is controlled by the tstamp_type, as described in the table below.
+
+   =================================  ===========================================
+            Timestamp Type                             Description
+   =================================  ===========================================
+   ``PCM_TSTAMP_TYPE_GETTIMEOFDAY``   System-wide realtime clock with seconds
+                                      since epoch.
+   ``PCM_TSTAMP_TYPE_MONOTONIC``      Monotonic time from an unspecified starting
+                                      time. Progress is NTP synchronized.
+   ``PCM_TSTAMP_TYPE_MONOTONIC_RAW``  Monotonic time from an unspecified starting
+                                      time using only the system clock.
+   =================================  ===========================================
+   
+   The timestamp mode is controlled by the tstamp_mode, as described in the table below.
+
+   =================================  ===========================================
+            Timestamp Mode                             Description
+   =================================  ===========================================
+   ``PCM_TSTAMP_NONE``                No timestamp.
+   ``PCM_TSTAMP_ENABLE``              Update timestamp at every hardware position
+                                      update.
+   =================================  ===========================================
+
 
 __ poll_objects_
 

--- a/recordtest.py
+++ b/recordtest.py
@@ -53,12 +53,15 @@ if __name__ == '__main__':
 		channels=1, rate=44100, format=alsaaudio.PCM_FORMAT_S16_LE, 
 		periodsize=160, device=device)
 
-	loops = 1000000
+	print(inp.info())
+	help(inp.htimestamp)
+
+	loops = 100000
 	while loops > 0:
 		loops -= 1
 		# Read data from device
 		l, data = inp.read()
-	  
 		if l:
+			print(l, inp.htimestamp(), time.time())
 			f.write(data)
 			time.sleep(.001)

--- a/recordtest.py
+++ b/recordtest.py
@@ -54,8 +54,8 @@ if __name__ == '__main__':
 		periodsize=160, device=device)
 
 	print(inp.info())
-	help(inp.htimestamp)
-
+	# help(inp.htimestamp)
+	inp.enable_timestamp()
 	loops = 100000
 	while loops > 0:
 		loops -= 1

--- a/recordtest.py
+++ b/recordtest.py
@@ -58,6 +58,7 @@ if __name__ == '__main__':
 		loops -= 1
 		# Read data from device
 		l, data = inp.read()
+
 		if l:
 			f.write(data)
 			time.sleep(.001)

--- a/recordtest.py
+++ b/recordtest.py
@@ -53,15 +53,11 @@ if __name__ == '__main__':
 		channels=1, rate=44100, format=alsaaudio.PCM_FORMAT_S16_LE, 
 		periodsize=160, device=device)
 
-	print(inp.info())
-	# help(inp.htimestamp)
-	inp.enable_timestamp()
-	loops = 100000
+	loops = 1000000
 	while loops > 0:
 		loops -= 1
 		# Read data from device
 		l, data = inp.read()
 		if l:
-			print(l, inp.htimestamp(), time.time())
 			f.write(data)
 			time.sleep(.001)


### PR DESCRIPTION
On raspberrypi I need to be able to set the tstamp type to get clock based time stamps. The functions added allow to read the type and the mode from ALSA and to set the type and mode. On the ALSA versions, I worked with, this works with plughw and hw. 

The dsnoop devices might need recent ALSA versions to work, that is the functions work on the older versions I used in that they change the sw_params but the sw_params don't affect ALSA behavior. The same might hold for dshare and dmix devices.

While debugging this it also became clear that ALSA version info might be handy. So there is also a function added at module level providing access to the version info.

I had some discussion with Jaroslav Kysela on how mode and type work, these discussions can be found [here](https://github.com/alsa-project/alsa-lib/issues/131). 

This pull request adds:

for PCM objects:
  set_tstamp_mode
  set_tstamp_type
  get_tstamp_mode
  get_tstamp_type

at module level:
  asoundlib_version
 
  /* PCM tstamp modes */
  PCM_TSTAMP_NONE
  PCM_TSTAMP_ENABLE
  
  /* PCM tstamp types */
  PCM_TSTAMP_TYPE_GETTIMEOFDAY
  PCM_TSTAMP_TYPE_MONOTONIC
  PCM_TSTAMP_TYPE_MONOTONIC_RAW