### PR TITLE
Fix polldescriptors() data types

### DIFF
--- a/alsaaudio.c
+++ b/alsaaudio.c
@@ -1732,7 +1732,7 @@ alsapcm_polldescriptors(alsapcm_t *self, PyObject *args)
 	for (i = 0; i < count; ++i)
 	{
 		PyList_SetItem(result, i,
-					   Py_BuildValue("II", fds[i].fd, fds[i].events));
+					   Py_BuildValue("ih", fds[i].fd, fds[i].events));
 	}
 
 	return result;
@@ -3001,7 +3001,7 @@ alsamixer_polldescriptors(alsamixer_t *self, PyObject *args)
 	for (i = 0; i < count; ++i)
 	{
 		PyList_SetItem(result, i,
-					   Py_BuildValue("II", fds[i].fd, fds[i].events));
+					   Py_BuildValue("ih", fds[i].fd, fds[i].events));
 	}
 
 	return result;


### PR DESCRIPTION
According to man and [poll.h](https://github.com/torvalds/linux/blob/a08b41ab9e2e468647f78eb17c28e29b93006394/include/uapi/asm-generic/poll.h#L36) `pollfd` is defined as:

```c
struct pollfd {
	int fd;
	short events;
	short revents;
};
````

Currently pyalsaaudio's code contradicts it. 

Due to this, pyalsaaudio performs incorrect conversion of FD with `-1` value (invalid descriptor). Validating such value in Python is not pretty:

```python
incorrect_fd = struct.unpack("I", b"\xFF\xFF\xFF\xFF")[0] # should be -1
```