### PR TITLE
Support decibel, percentage, and raw volumes in getvolume, setvolume, and getrange

### DIFF
--- a/alsaaudio.c
+++ b/alsaaudio.c
@@ -306,7 +306,7 @@ Return the card name and long name for card 'card_index'.");
 
 
 static PyObject *
-alsapcm_list(PyObject *self, PyObject *args)
+alsapcm_list(PyObject *self, PyObject *args, PyObject *kwds)
 {
 	PyObject *pcmtypeobj = NULL;
 	long pcmtype;
@@ -316,8 +316,11 @@ alsapcm_list(PyObject *self, PyObject *args)
 	char *name, *io;
 	const char *filter;
 
-	if (!PyArg_ParseTuple(args,"|O:pcms", &pcmtypeobj))
+	char *kw[] = { "pcmtype", NULL };
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O:pcms", kw, &pcmtypeobj)) {
 		return NULL;
+	}
 
 	pcmtype = get_pcmtype(pcmtypeobj);
 	if (pcmtype < 0) {
@@ -2350,7 +2353,7 @@ static long alsamixer_getphysvolume(long min, long max, int percentage)
 }
 
 static PyObject *
-alsamixer_getvolume(alsamixer_t *self, PyObject *args)
+alsamixer_getvolume(alsamixer_t *self, PyObject *args, PyObject *kwds)
 {
 	snd_mixer_elem_t *elem;
 	int channel;
@@ -2360,8 +2363,11 @@ alsamixer_getvolume(alsamixer_t *self, PyObject *args)
 	PyObject *result;
 	PyObject *item;
 
-	if (!PyArg_ParseTuple(args,"|O:getvolume", &pcmtypeobj))
+	char *kw[] = { "pcmtype", NULL };
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O:getvolume", kw, &pcmtypeobj)) {
 		return NULL;
+	}
 
 	if (!self->handle)
 	{
@@ -2426,13 +2432,15 @@ if the mixer has this capability, otherwise PCM_CAPTURE");
 
 
 static PyObject *
-alsamixer_getrange(alsamixer_t *self, PyObject *args)
+alsamixer_getrange(alsamixer_t *self, PyObject *args, PyObject *kwds)
 {
 	snd_mixer_elem_t *elem;
 	PyObject *pcmtypeobj = NULL;
 	long pcmtype;
 
-	if (!PyArg_ParseTuple(args,"|O:getrange", &pcmtypeobj)) {
+	char *kw[] = { "pcmtype", NULL };
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O:getrange", kw, &pcmtypeobj)) {
 		return NULL;
 	}
 
@@ -2494,7 +2502,7 @@ PyDoc_STRVAR(getrange_doc,
 \n\
 Returns a list of tuples with the volume range (ints).\n\
 \n\
-The optional 'direction' argument can be either PCM_PLAYBACK or\n\
+The optional 'pcmtype' argument can be either PCM_PLAYBACK or\n\
 PCM_CAPTURE, which is relevant if the mixer can control both\n\
 playback and capture volume. The default value is 'playback'\n\
 if the mixer has this capability, otherwise 'capture'");
@@ -2748,7 +2756,7 @@ This method will fail if the mixer has no capture switch capabilities.");
 
 
 static PyObject *
-alsamixer_setvolume(alsamixer_t *self, PyObject *args)
+alsamixer_setvolume(alsamixer_t *self, PyObject *args, PyObject *kwds)
 {
 	snd_mixer_elem_t *elem;
 	int i;
@@ -2759,9 +2767,12 @@ alsamixer_setvolume(alsamixer_t *self, PyObject *args)
 	int channel = MIXER_CHANNEL_ALL;
 	int done = 0;
 
-	if (!PyArg_ParseTuple(args,"l|iO:setvolume", &volume, &channel,
-						  &pcmtypeobj))
+	char *kw[] = { "volume", "channel", "pcmtype", NULL };
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "l|iO:setvolume", kw, &volume,
+		&channel, &pcmtypeobj)) {
 		return NULL;
+	}
 
 	if (volume < 0 || volume > 100)
 	{
@@ -2833,7 +2844,7 @@ If the optional argument channel is present, the volume is set only for\n\
 this channel. This assumes that the mixer can control the volume for the\n\
 channels independently.\n\
 \n\
-The optional direction argument can be either PCM_PLAYBACK or PCM_CAPTURE.\n\
+The optional 'pcmtype' argument can be either PCM_PLAYBACK or PCM_CAPTURE.\n\
 It is relevant if the mixer has independent playback and capture volume\n\
 capabilities, and controls which of the volumes will be changed.\n\
 The default is 'playback' if the mixer has this capability, otherwise\n\
@@ -3055,13 +3066,13 @@ static PyMethodDef alsamixer_methods[] = {
 	 switchcap_doc},
 	{"volumecap", (PyCFunction)alsamixer_volumecap, METH_VARARGS,
 	 volumecap_doc},
-	{"getvolume", (PyCFunction)alsamixer_getvolume, METH_VARARGS,
+	{"getvolume", (PyCFunction)alsamixer_getvolume, METH_VARARGS | METH_KEYWORDS,
 	 getvolume_doc},
-	{"getrange", (PyCFunction)alsamixer_getrange, METH_VARARGS, getrange_doc},
+	{"getrange", (PyCFunction)alsamixer_getrange, METH_VARARGS | METH_KEYWORDS, getrange_doc},
 	{"getenum", (PyCFunction)alsamixer_getenum, METH_VARARGS, getenum_doc},
 	{"getmute", (PyCFunction)alsamixer_getmute, METH_VARARGS, getmute_doc},
 	{"getrec", (PyCFunction)alsamixer_getrec, METH_VARARGS, getrec_doc},
-	{"setvolume", (PyCFunction)alsamixer_setvolume, METH_VARARGS,
+	{"setvolume", (PyCFunction)alsamixer_setvolume, METH_VARARGS | METH_KEYWORDS,
 	 setvolume_doc},
 	{"setenum", (PyCFunction)alsamixer_setenum, METH_VARARGS, setenum_doc},
 	{"setmute", (PyCFunction)alsamixer_setmute, METH_VARARGS, setmute_doc},
@@ -3137,7 +3148,7 @@ static PyMethodDef alsaaudio_methods[] = {
 	{ "card_indexes", (PyCFunction)alsacard_list_indexes, METH_VARARGS, card_indexes_doc},
 	{ "card_name", (PyCFunction)alsacard_name, METH_VARARGS, card_name_doc},
 	{ "cards", (PyCFunction)alsacard_list, METH_VARARGS, cards_doc},
-	{ "pcms", (PyCFunction)alsapcm_list, METH_VARARGS, pcms_doc},
+	{ "pcms", (PyCFunction)alsapcm_list, METH_VARARGS|METH_KEYWORDS, pcms_doc},
 	{ "mixers", (PyCFunction)alsamixer_list, METH_VARARGS|METH_KEYWORDS, mixers_doc},
 	{ 0, 0 },
 };

--- a/doc/libalsaaudio.rst
+++ b/doc/libalsaaudio.rst
@@ -33,13 +33,13 @@ The :mod:`alsaaudio` module defines functions and classes for using ALSA.
 .. % should be enclosed in \var{...}.
 
 
-.. function:: pcms([type=PCM_PLAYBACK])
+.. function:: pcms(pcmtype=PCM_PLAYBACK)
 
    List available PCM devices by name.
    
    Arguments are:
 
-   * *type* - can be either :const:`PCM_CAPTURE` or :const:`PCM_PLAYBACK`
+   * *pcmtype* - can be either :const:`PCM_CAPTURE` or :const:`PCM_PLAYBACK`
      (default).  
 
    **Note:**
@@ -466,11 +466,11 @@ Mixer objects have the following methods:
    This method will fail if the mixer has no playback switch capabilities.
 
 
-.. method:: Mixer.getrange([direction])
+.. method:: Mixer.getrange(pcmtype=PCM_PLAYBACK)
 
    Return the volume range of the ALSA mixer controlled by this object.
 
-   The optional *direction* argument can be either :const:`PCM_PLAYBACK` or
+   The optional *pcmtype* argument can be either :const:`PCM_PLAYBACK` or
    :const:`PCM_CAPTURE`, which is relevant if the mixer can control both
    playback and capture volume.  The default value is :const:`PCM_PLAYBACK`
    if the mixer has playback channels, otherwise it is :const:`PCM_CAPTURE`.
@@ -484,18 +484,18 @@ Mixer objects have the following methods:
    This method will fail if the mixer has no capture switch capabilities.
 
 
-.. method:: Mixer.getvolume([direction])
+.. method:: Mixer.getvolume(pcmtype=PCM_PLAYBACK)
 
    Returns a list with the current volume settings for each channel. The list
    elements are integer percentages.
 
-   The optional *direction* argument can be either :const:`PCM_PLAYBACK` or
+   The optional *pcmtype* argument can be either :const:`PCM_PLAYBACK` or
    :const:`PCM_CAPTURE`, which is relevant if the mixer can control both
    playback and capture volume. The default value is :const:`PCM_PLAYBACK`
    if the mixer has playback channels, otherwise it is :const:`PCM_CAPTURE`.
 
 
-.. method:: Mixer.setvolume(volume, [channel], [direction])
+.. method:: Mixer.setvolume(volume, channel=None, pcmtype=PCM_PLAYBACK)
 
    Change the current volume settings for this mixer. The *volume* argument
    controls the new volume setting as an integer percentage.
@@ -504,7 +504,7 @@ Mixer objects have the following methods:
    only for this channel. This assumes that the mixer can control the
    volume for the channels independently.
 
-   The optional *direction* argument can be either :const:`PCM_PLAYBACK` or
+   The optional *pcmtype* argument can be either :const:`PCM_PLAYBACK` or
    :const:`PCM_CAPTURE`, which is relevant if the mixer can control both
    playback and capture volume. The default value is :const:`PCM_PLAYBACK`
    if the mixer has playback channels, otherwise it is :const:`PCM_CAPTURE`.

--- a/mixertest.py
+++ b/mixertest.py
@@ -49,25 +49,30 @@ def show_mixer(name, kwargs):
 
     if "Volume" in volcap or "Joined Volume" in volcap or "Playback Volume" in volcap:
         pmin, pmax = mixer.getrange(alsaaudio.PCM_PLAYBACK)
-        pmin_keyword, pmax_keyword = mixer.getrange(pcmtype=alsaaudio.PCM_PLAYBACK)
+        pmin_keyword, pmax_keyword = mixer.getrange(pcmtype=alsaaudio.PCM_PLAYBACK, units=alsaaudio.VOLUME_UNITS_RAW)
         pmin_default, pmax_default = mixer.getrange()
         assert pmin == pmin_keyword
         assert pmax == pmax_keyword
         assert pmin == pmin_default
         assert pmax == pmax_default
         print("Raw playback volume range {}-{}".format(pmin, pmax))
+        pmin_dB, pmax_dB = mixer.getrange(units=alsaaudio.VOLUME_UNITS_DB)
+        print("dB playback volume range {}-{}".format(pmin_dB / 100.0, pmax_dB / 100.0))
 
     if "Capture Volume" in volcap or "Joined Capture Volume" in volcap:
         # Check that `getrange` works with keyword and positional arguments
         cmin, cmax = mixer.getrange(alsaaudio.PCM_CAPTURE)
-        cmin_keyword, cmax_keyword = mixer.getrange(pcmtype=alsaaudio.PCM_CAPTURE)
+        cmin_keyword, cmax_keyword = mixer.getrange(pcmtype=alsaaudio.PCM_CAPTURE, units=alsaaudio.VOLUME_UNITS_RAW)
         assert cmin == cmin_keyword
         assert cmax == cmax_keyword
         print("Raw capture volume range {}-{}".format(cmin, cmax))
+        cmin_dB, cmax_dB = mixer.getrange(pcmtype=alsaaudio.PCM_CAPTURE, units=alsaaudio.VOLUME_UNITS_DB)
+        print("dB capture volume range {}-{}".format(cmin_dB / 100.0, cmax_dB / 100.0))
 
     volumes = mixer.getvolume()
+    volumes_dB = mixer.getvolume(units=alsaaudio.VOLUME_UNITS_DB)
     for i in range(len(volumes)):
-        print("Channel %i volume: %i%%" % (i,volumes[i]))
+        print("Channel %i volume: %i%% (%.1f dB)" % (i, volumes[i], volumes_dB[i] / 100.0))
         
     try:
         mutes = mixer.getmute()

--- a/mixertest.py
+++ b/mixertest.py
@@ -43,8 +43,28 @@ def show_mixer(name, kwargs):
         sys.exit(1)
 
     print("Mixer name: '%s'" % mixer.mixer())
-    print("Capabilities: %s %s" % (' '.join(mixer.volumecap()),
+    volcap = mixer.volumecap()
+    print("Capabilities: %s %s" % (' '.join(volcap),
                                    ' '.join(mixer.switchcap())))
+
+    if "Volume" in volcap or "Joined Volume" in volcap or "Playback Volume" in volcap:
+        pmin, pmax = mixer.getrange(alsaaudio.PCM_PLAYBACK)
+        pmin_keyword, pmax_keyword = mixer.getrange(pcmtype=alsaaudio.PCM_PLAYBACK)
+        pmin_default, pmax_default = mixer.getrange()
+        assert pmin == pmin_keyword
+        assert pmax == pmax_keyword
+        assert pmin == pmin_default
+        assert pmax == pmax_default
+        print("Raw playback volume range {}-{}".format(pmin, pmax))
+
+    if "Capture Volume" in volcap or "Joined Capture Volume" in volcap:
+        # Check that `getrange` works with keyword and positional arguments
+        cmin, cmax = mixer.getrange(alsaaudio.PCM_CAPTURE)
+        cmin_keyword, cmax_keyword = mixer.getrange(pcmtype=alsaaudio.PCM_CAPTURE)
+        assert cmin == cmin_keyword
+        assert cmax == cmax_keyword
+        print("Raw capture volume range {}-{}".format(cmin, cmax))
+
     volumes = mixer.getvolume()
     for i in range(len(volumes)):
         print("Channel %i volume: %i%%" % (i,volumes[i]))


### PR DESCRIPTION
This addresses issue #8 - "Imprecise conversion from db to percent and vice-versa on mixer interface".

This PR is two commits. The first is a preparatory commit that converts the above mentioned functions to use keyword arguments.
The second adds a new kwarg, `units`, which allows the user to select `VOLUME_UNITS_PERCENTAGE`, `VOLUME_UNITS_RAW`, or `VOLUME_UNITS_DB` as required.
The default value of `units` keeps the behaviour consistent with previous versions of `pyalsaaudio`. I.e., `setvolume` and `getvolume` use percentages, and `getrange` uses raw/physical values.

Tests and documentation are updated where appropriate.

Thanks!

