### PR TITLE
alsamixer_getvolume: Fix incorrect parenthesis

### DIFF
--- a/alsaaudio.c
+++ b/alsaaudio.c
@@ -2411,13 +2411,13 @@ alsamixer_getvolume(alsamixer_t *self, PyObject *args, PyObject *kwds)
 
 	elem = alsamixer_find_elem(self->handle,self->controlname,self->controlid);
 
-	if (!pcmtypeobj || (pcmtypeobj == Py_None)) {
+	if (!pcmtypeobj || (pcmtypeobj == Py_None))
+	{
 		if (self->pchannels) {
 			pcmtype = SND_PCM_STREAM_PLAYBACK;
+		} else {
+			pcmtype = SND_PCM_STREAM_CAPTURE;
 		}
-	}
-	else {
-		pcmtype = SND_PCM_STREAM_CAPTURE;
 	}
 
 	result = PyList_New(0);

--- a/alsaaudio.c
+++ b/alsaaudio.c
@@ -2411,11 +2411,11 @@ alsamixer_getvolume(alsamixer_t *self, PyObject *args, PyObject *kwds)
 
 	elem = alsamixer_find_elem(self->handle,self->controlname,self->controlid);
 
-	if (!pcmtypeobj || (pcmtypeobj == Py_None))
-	{
+	if (!pcmtypeobj || (pcmtypeobj == Py_None)) {
 		if (self->pchannels) {
 			pcmtype = SND_PCM_STREAM_PLAYBACK;
-		} else {
+		}
+		else {
 			pcmtype = SND_PCM_STREAM_CAPTURE;
 		}
 	}


### PR DESCRIPTION
The pcmtypeobj check is overriding the pcmtype if the object is not NULL
or Py_None, making it impossible to get the playback volume. Fix the
paranthesis so that pcmtype is only overwritten when pcmtypeobj is not
set.