### PR TITLE
Use correct sample bit width

### DIFF
--- a/alsaaudio.c
+++ b/alsaaudio.c
@@ -403,7 +403,7 @@ static int alsapcm_setup(alsapcm_t *self)
 	snd_pcm_hw_params_get_period_size(hwparams, &self->periodsize, &dir);
 	snd_pcm_hw_params_get_periods(hwparams, &self->periods, &dir);
 
-	self->framesize = self->channels * snd_pcm_hw_params_get_sbits(hwparams)/8;
+	self->framesize = self->channels * snd_pcm_format_physical_width(self->format)/8;
 
 	return res;
 }


### PR DESCRIPTION
snd_pcm_hw_params_get_sbits gives the number of significant bits, not the actual number of bits stored. Change to snd_pcm_format_physical_width.

This fixes a bug where, for example on my hardware:
format = 'S32_LE'
significant bits = 24
physical bits = 32

the program will segfault because the allocated buffer is too small.