### PR TITLE
Fix 404 Links in the Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 For documentation, see http://larsimmisch.github.io/pyalsaaudio/
 
-> Author: Casper Wilstrup (cwi@aves.dk)
+> Author: Casper Wilstrup (cwi@aves.dk)  
 > Maintainer: Lars Immisch (lars@ibp.de)
 
 This package contains wrappers for accessing the
@@ -57,8 +57,8 @@ distribution; it is also online on [http://larsimmisch.github.io/pyalsaaudio/](h
 
 There are some example programs included with the source:
 
-* [playwav.py](https://github.com/larsimmisch/pyalsaaudio/blob/master/playwav.py) plays back a wav file
-* [playbacktest.py](https://github.com/larsimmisch/pyalsaaudio/blob/master/playbacktest.py) plays back raw sound data read from stdin
-* [recordtest.py](https://github.com/larsimmisch/pyalsaaudio/blob/master/recordtest.py) captures sound from the microphone and writes
+* [playwav.py](./examples/playwav.py) plays back a wav file
+* [playbacktest.py](./examples/playbacktest.py) plays back raw sound data read from stdin
+* [recordtest.py](./examples/recordtest.py) captures sound from the microphone and writes
 it raw to stdout.
-* [mixertest.py](https://github.com/larsimmisch/pyalsaaudio/blob/master/mixertest.py) can be used to manipulate the mixers.
+* [mixertest.py](./examples/mixertest.py) can be used to manipulate the mixers.


### PR DESCRIPTION
Example file's links are broken because of rename master => main and moving to examples folder.

Alternative fix would be to use updated link:
https://github.com/larsimmisch/pyalsaaudio/blob/**main/examples**/mixertest.py 